### PR TITLE
2 :: Fixing relations, currencies now uses seq id

### DIFF
--- a/rails_app/app/controllers/application_controller.rb
+++ b/rails_app/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_devise_parameters, if: :devise_controller?
 
   def configure_permitted_devise_parameters
-    devise_parameter_sanitizer.permit(:account_update, keys: [:favorite_currency_code])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:favorite_currency_id])
   end
 
     # Overwriting the sign_out redirect path method

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -47,7 +47,9 @@ class CurrenciesController < ApplicationController
   end
 
   def change_favorite
-    if current_user.update favorite_currency_id: params[:user][:favorite_currency_id]
+    new_favorite = Currency.find_by id: params[:user][:favorite_currency_id]
+
+    if current_user.update favorite_currency: new_favorite
       redirect_to root_path
     end
   end

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -9,8 +9,6 @@ class CurrenciesController < ApplicationController
 
   # GET /currencies or /currencies.json
   def index
-    puts "signed in = #{user_signed_in?}"
-
     if user_signed_in?
       redirect_to followed_currencies_path
     else

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -5,7 +5,7 @@
 #
 class CurrenciesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:follow, :unfollow, :followed]
+  before_action :authenticate_user!, only: [:follow, :unfollow, :followed, :change_favorite, :edit_favorite]
 
   # GET /currencies or /currencies.json
   def index
@@ -38,6 +38,16 @@ class CurrenciesController < ApplicationController
       user = current_user
 
       @followed_codes = user.followed_currencies.map { |curr| curr.code }
+    end
+  end
+
+  def edit_favorite
+    @user = current_user
+  end
+
+  def change_favorite
+    if current_user.update favorite_currency_id: params[:user][:favorite_currency_id]
+      redirect_to root_path
     end
   end
 

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -5,7 +5,7 @@
 #
 class CurrenciesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:follow, :unfollow, :followed, :change_favorite, :edit_favorite]
+  before_action :authenticate_user!, except: [:index, :show, :all]
 
   # GET /currencies or /currencies.json
   def index
@@ -15,6 +15,18 @@ class CurrenciesController < ApplicationController
       redirect_to all_currencies_path
     end
   end
+  
+  # GET /currencies/all or /currencies/all.json
+  def all
+    @currencies = Currency.all
+
+    if user_signed_in?
+      user = current_user
+
+      @followed_codes = user.followed_currencies.map { |curr| curr.code }
+    end
+  end
+
 
   # GET /currencies/EUR or /currencies/EUR.json
   def show
@@ -28,17 +40,6 @@ class CurrenciesController < ApplicationController
     @currencies = user.followed_currencies
 
     @followed_codes = @currencies.map { |curr| curr.code }
-  end
-
-  # GET /currencies/all or /currencies/all.json
-  def all
-    @currencies = Currency.all
-
-    if user_signed_in?
-      user = current_user
-
-      @followed_codes = user.followed_currencies.map { |curr| curr.code }
-    end
   end
 
   def edit_favorite
@@ -67,6 +68,7 @@ class CurrenciesController < ApplicationController
     handle_result CurrencyFollowerManager.call user: user, currency: currency, follow: false
   end
 
+  private
   #
   # Handles the result of an interactor
   #

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -23,7 +23,7 @@ class CurrenciesController < ApplicationController
     if user_signed_in?
       user = current_user
 
-      @followed_codes = user.followed_currencies.map { |curr| curr.code }
+      @followed_codes = user.followed_currencies.pluck(:code)
     end
   end
 
@@ -39,7 +39,7 @@ class CurrenciesController < ApplicationController
 
     @currencies = user.followed_currencies
 
-    @followed_codes = @currencies.map { |curr| curr.code }
+    @followed_codes = @currencies.pluck(:code)
   end
 
   def edit_favorite

--- a/rails_app/app/helpers/currencies_helper.rb
+++ b/rails_app/app/helpers/currencies_helper.rb
@@ -40,7 +40,6 @@ module CurrenciesHelper
       end
       
       ex_rate = ex_rate.round(decimal_places)
-      puts "t"
     end
 
     return ex_rate

--- a/rails_app/app/helpers/currencies_helper.rb
+++ b/rails_app/app/helpers/currencies_helper.rb
@@ -51,7 +51,7 @@ module CurrenciesHelper
 
     # if the user has a favorite currency get the record for the same date and relativize
     if user_signed_in? && current_user.favorite_currency != nil
-      ex_rate = CurrencyRecord.find_by(currency_id: current_user.favorite_currency.code,
+      ex_rate = CurrencyRecord.find_by(currency_id: current_user.favorite_currency.id,
         record_date: record.record_date).latest_exchange_rate / ex_rate
     end
 

--- a/rails_app/app/helpers/currencies_helper.rb
+++ b/rails_app/app/helpers/currencies_helper.rb
@@ -33,7 +33,7 @@ module CurrenciesHelper
 
     # round if needed
     if round
-      ex_rate = ex_rate.round(user_signed_in? && current_user.favorite_currency != nil ? current_user.favorite_currency.decimal_digits : currency.decimal_digits)
+      ex_rate = ex_rate.round(user_signed_in? && current_user.favorite_currency != nil ? current_user.favorite_currency.decimal_digits : (currency.decimal_digits || 0))
     end
 
     return ex_rate
@@ -44,7 +44,7 @@ module CurrenciesHelper
 
     # if the user has a favorite currency get the record for the same date and relativize
     if user_signed_in? && current_user.favorite_currency != nil
-      ex_rate = CurrencyRecord.find_by(code: current_user.favorite_currency.code,
+      ex_rate = CurrencyRecord.find_by(currency_id: current_user.favorite_currency.code,
         record_date: record.record_date).latest_exchange_rate / ex_rate
     end
 

--- a/rails_app/app/helpers/currencies_helper.rb
+++ b/rails_app/app/helpers/currencies_helper.rb
@@ -33,7 +33,14 @@ module CurrenciesHelper
 
     # round if needed
     if round
-      ex_rate = ex_rate.round(user_signed_in? && current_user.favorite_currency != nil ? current_user.favorite_currency.decimal_digits : (currency.decimal_digits || 0))
+      decimal_places = if user_signed_in? && current_user.favorite_currency
+        current_user.favorite_currency.decimal_digits
+      else
+        currency.decimal_digits || 0
+      end
+      
+      ex_rate = ex_rate.round(decimal_places)
+      puts "t"
     end
 
     return ex_rate

--- a/rails_app/app/jobs/load_currencies_history_job.rb
+++ b/rails_app/app/jobs/load_currencies_history_job.rb
@@ -7,7 +7,7 @@ class LoadCurrenciesHistoryJob < ApplicationJob
     options[:date_range] ||= (DateTime.now.to_date - 1.day - 1.week)..(DateTime.now.to_date - 1.day)
 
     puts options[:date_range]
-    
+
     # update record list
     result = FreecurrencyApi.call endpoint: "historical", options: { date_from: options[:date_range].first, date_to: options[:date_range].last }
 

--- a/rails_app/app/jobs/load_currencies_history_job.rb
+++ b/rails_app/app/jobs/load_currencies_history_job.rb
@@ -15,7 +15,7 @@ class LoadCurrenciesHistoryJob < ApplicationJob
       unless result.failure?
         result.data.each do |date, records|
           records.each do |currency_code, ex_rate|
-            record = CurrencyRecord.find_or_initialize_by record_date: date.to_date, code: currency_code
+            record = CurrencyRecord.find_or_initialize_by record_date: date.to_date, currency: Currency.find_by(code: currency_code)
             record.update latest_exchange_rate: ex_rate
           end
         end

--- a/rails_app/app/models/currency.rb
+++ b/rails_app/app/models/currency.rb
@@ -8,11 +8,13 @@ class Currency < ApplicationRecord
   validates :name, presence: true
   validates :name_plural, presence: true
 
-  has_many :currency_followings, primary_key: :code, foreign_key: :followed_currency_code, dependent: :destroy
+  has_many :currency_followings, dependent: :destroy
 
-  has_many :favorited_by, class_name: "User", foreign_key: :favorite_currency_code, primary_key: :code
+  has_many :followers, class_name: "User", through: :currency_followings
 
-  has_many :history, class_name: "CurrencyRecord", foreign_key: :code, primary_key: :code
+  has_many :favorited_by, class_name: "User", foreign_key: :favorite_currency_id
+
+  has_many :history, class_name: "CurrencyRecord"
 
   def code=(val)
     self[:code] = val

--- a/rails_app/app/models/currency_following.rb
+++ b/rails_app/app/models/currency_following.rb
@@ -7,6 +7,6 @@ class CurrencyFollowing < ApplicationRecord
             uniqueness: { scope: :followed_currency, message: "must be assigned to each currency at most once." }
   validates :followed_currency, uniqueness: { scope: :follower, message: "must be assigned to each user at most once." }
 
-  belongs_to :follower, class_name: "User", primary_key: :email, foreign_key: :follower_email
-  belongs_to :followed_currency, class_name: "Currency", primary_key: :code, foreign_key: :followed_currency_code
+  belongs_to :follower, class_name: "User", foreign_key: :user_id
+  belongs_to :followed_currency, class_name: "Currency", foreign_key: :currency_id
 end

--- a/rails_app/app/models/currency_record.rb
+++ b/rails_app/app/models/currency_record.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 class CurrencyRecord < ApplicationRecord
 
-    # same requirements as Currency
-  validates :code, presence: true, uniqueness: { scope: :record_date }
+  # same requirements as Currency
+  validates :currency_id, presence: true, uniqueness: { scope: :record_date }
   validates :record_date, presence: true
   validates :latest_exchange_rate, allow_nil: true, numericality: { greater_than: 0 }
 
-  belongs_to :currency, foreign_key: :code
+  belongs_to :currency
 
 end

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -7,9 +7,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :currency_followings, primary_key: :email, foreign_key: :follower_email, dependent: :destroy
-  has_many :followed_currencies, through: :currency_followings, class_name: "Currency"
+  has_many :currency_followings, dependent: :destroy
+  has_many :followed_currencies, through: :currency_followings, class_name: "Currency", foreign_key: :currency_id
 
-  belongs_to :favorite_currency, class_name: "Currency", foreign_key: :favorite_currency_code, optional: true
+  belongs_to :favorite_currency, class_name: "Currency", foreign_key: :favorite_currency_id, optional: true
 
 end

--- a/rails_app/app/views/currencies/_currency_graph.html.erb
+++ b/rails_app/app/views/currencies/_currency_graph.html.erb
@@ -14,7 +14,7 @@
     <% currency_codes.each do | currency_code | %>
       {
         label: "<%= sanitize currency_code %> exchange rate",
-        data: <%= sanitize CurrencyRecord.where(code: currency_code, record_date: graph_range.to_a)
+        data: <%= sanitize CurrencyRecord.where(currency: Currency.find_by(code: currency_code), record_date: graph_range.to_a)
           .order(:record_date).map { | record | relativize_record_ex_rate record }.to_s %>,
         borderWidth: 1
       },

--- a/rails_app/app/views/currencies/edit_favorite.html.erb
+++ b/rails_app/app/views/currencies/edit_favorite.html.erb
@@ -1,0 +1,18 @@
+<div class="page-form">
+
+  <h1>Edit Favorite Currency</h1>
+
+  <%= form_for(@user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: @user %>
+
+    <div class="field">
+      <%= f.label :favorite_currency_id %>
+      <%= f.select :favorite_currency_id, Currency.all.collect { |curr| ["#{curr.symbol}: #{curr.name}", curr.id] }, include_blank: true %>
+    </div>
+
+    <%= f.submit "Update" %>
+
+  <% end %>
+
+</div>
+

--- a/rails_app/app/views/currencies/edit_favorite.html.erb
+++ b/rails_app/app/views/currencies/edit_favorite.html.erb
@@ -2,8 +2,8 @@
 
   <h1>Edit Favorite Currency</h1>
 
-  <%= form_for(@user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: @user %>
+  <%= form_for(current_user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: current_user %>
 
     <div class="field">
       <%= f.label :favorite_currency_id %>

--- a/rails_app/app/views/layouts/application.html.erb
+++ b/rails_app/app/views/layouts/application.html.erb
@@ -42,7 +42,9 @@
 
       <div class="container py-4 px-8">
         <% if defined?(current_user.favorite_currency) && current_user.favorite_currency != nil %>
-          Your favorite currency is <%= current_user.favorite_currency.code %> (<%= current_user.favorite_currency.symbol %>)
+          Your favorite currency is <%= current_user.favorite_currency.code %> (<%= current_user.favorite_currency.symbol %>). Change it <%= link_to "here", change_favorite_currency_path %>
+        <% else %>
+          You don't have a favorite currency. Set one <%= link_to "here", change_favorite_currency_path %>
         <% end %>
         <div class="max-w-full flex flex-col gap-5 place-items-center">
           <%= yield %>

--- a/rails_app/app/views/users/registrations/edit.html.erb
+++ b/rails_app/app/views/users/registrations/edit.html.erb
@@ -36,7 +36,8 @@
     </div>
 
     <div class="field">
-      <%= f.select :favorite_currency_code, Currency.all.collect { |curr| ["#{curr.symbol}: #{curr.name}", curr.code] }, include_blank: true %>
+      <%= f.label :favorite_currency_id %>
+      <%= f.select :favorite_currency_id, Currency.all.collect { |curr| ["#{curr.symbol}: #{curr.name}", curr.id] }, include_blank: true %>
     </div>
 
     <%= f.submit "Update" %>

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   get "currencies/followed", to: "currencies#followed", as: "followed_currencies"
   get "currencies/all", to: "currencies#all", as: "all_currencies"
+  get "currencies/change_favorite", to: "currencies#edit_favorite", as: "edit_favorite_currency"
+  put "currencies/change_favorite", to: "currencies#change_favorite", as: "change_favorite_currency"
 
   resources :currencies, only: [:show, :index] do
 

--- a/rails_app/db/migrate/20230420085710_change_currencies_pk.rb
+++ b/rails_app/db/migrate/20230420085710_change_currencies_pk.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ChangeCurrenciesPk < ActiveRecord::Migration[7.0]
   def change
     execute "ALTER TABLE currencies DROP CONSTRAINT currencies_pkey CASCADE;"

--- a/rails_app/db/migrate/20230420085710_change_currencies_pk.rb
+++ b/rails_app/db/migrate/20230420085710_change_currencies_pk.rb
@@ -1,0 +1,7 @@
+class ChangeCurrenciesPk < ActiveRecord::Migration[7.0]
+  def change
+    execute "ALTER TABLE currencies DROP CONSTRAINT currencies_pkey CASCADE;"
+
+    add_column :currencies, :id, :primary_key
+  end
+end

--- a/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
+++ b/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
@@ -1,0 +1,33 @@
+class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
+  def change
+    change_table :currency_followings do |t|
+
+      t.remove_index([:follower_email, :followed_currency_code])
+
+      t.remove_foreign_key column: :follower_email if t.foreign_key_exists? column: :follower_email
+      
+      t.remove_foreign_key column: :followed_currency_code if t.foreign_key_exists? column: :followed_currency_code
+
+      t.bigint :currency_id
+      t.foreign_key :currencies
+
+      t.bigint :user_id
+      t.foreign_key :users
+
+      t.index [ :user_id, :currency_id ], name: "unique_user+currency", unique: true
+    end
+
+    change_table :currency_records do |t|
+      t.remove_index :code
+      t.remove_index [ :code, :record_date ]
+
+      t.remove_foreign_key column: :code if t.foreign_key_exists? column: :code
+
+      t.bigint :currency_id
+      t.foreign_key :currencies
+
+      t.index :currency_id
+      t.index [ :currency_id, :record_date ], name: "unique_currency+date", unique: true
+    end
+  end
+end

--- a/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
+++ b/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
   def change
     change_table :currency_followings do |t|
@@ -5,7 +6,7 @@ class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
       t.remove_index([:follower_email, :followed_currency_code])
 
       t.remove_foreign_key column: :follower_email if t.foreign_key_exists? column: :follower_email
-      
+
       t.remove_foreign_key column: :followed_currency_code if t.foreign_key_exists? column: :followed_currency_code
 
       t.bigint :currency_id
@@ -14,12 +15,12 @@ class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
       t.bigint :user_id
       t.foreign_key :users
 
-      t.index [ :user_id, :currency_id ], name: "unique_user+currency", unique: true
+      t.index [:user_id, :currency_id], name: "unique_user+currency", unique: true
     end
 
     change_table :currency_records do |t|
       t.remove_index :code
-      t.remove_index [ :code, :record_date ]
+      t.remove_index [:code, :record_date]
 
       t.remove_foreign_key column: :code if t.foreign_key_exists? column: :code
 
@@ -27,7 +28,7 @@ class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
       t.foreign_key :currencies
 
       t.index :currency_id
-      t.index [ :currency_id, :record_date ], name: "unique_currency+date", unique: true
+      t.index [:currency_id, :record_date], name: "unique_currency+date", unique: true
     end
   end
 end

--- a/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
+++ b/rails_app/db/migrate/20230420085950_change_relations_use_pk.rb
@@ -5,9 +5,8 @@ class ChangeRelationsUsePk < ActiveRecord::Migration[7.0]
 
       t.remove_index([:follower_email, :followed_currency_code])
 
-      t.remove_foreign_key column: :follower_email if t.foreign_key_exists? column: :follower_email
-
-      t.remove_foreign_key column: :followed_currency_code if t.foreign_key_exists? column: :followed_currency_code
+      t.remove_foreign_key column: :follower_email
+      t.remove_foreign_key column: :followed_currency_code
 
       t.bigint :currency_id
       t.foreign_key :currencies

--- a/rails_app/db/migrate/20230420093748_fix_relations.rb
+++ b/rails_app/db/migrate/20230420093748_fix_relations.rb
@@ -1,0 +1,11 @@
+class FixRelations < ActiveRecord::Migration[7.0]
+  def change
+
+    remove_column :currency_records, :code
+    remove_column :users, :favorite_currency_code
+
+    add_column :users, :favorite_currency_id, :bigint
+    add_foreign_key :users, :currencies, column: :favorite_currency_id
+
+  end
+end

--- a/rails_app/db/migrate/20230420093748_fix_relations.rb
+++ b/rails_app/db/migrate/20230420093748_fix_relations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class FixRelations < ActiveRecord::Migration[7.0]
   def change
 

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_143019) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_20_093748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "currencies", primary_key: "code", id: :string, force: :cascade do |t|
+  create_table "currencies", force: :cascade do |t|
+    t.string "code", null: false
     t.float "latest_exchange_rate"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -29,18 +30,35 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_143019) do
     t.string "followed_currency_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["follower_email", "followed_currency_code"], name: "unique_on_follower_+_followed_currency", unique: true
+    t.bigint "currency_id"
+    t.bigint "user_id"
+    t.index ["user_id", "currency_id"], name: "unique_user+currency", unique: true
   end
 
   create_table "currency_records", force: :cascade do |t|
-    t.string "code", null: false
     t.date "record_date", null: false
     t.float "latest_exchange_rate", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["code", "record_date"], name: "index_currency_records_on_code_and_record_date", unique: true
-    t.index ["code"], name: "index_currency_records_on_code"
+    t.bigint "currency_id"
+    t.index ["currency_id", "record_date"], name: "unique_currency+date", unique: true
+    t.index ["currency_id"], name: "index_currency_records_on_currency_id"
     t.index ["record_date"], name: "index_currency_records_on_record_date"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "users", force: :cascade do |t|
@@ -51,13 +69,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_143019) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "favorite_currency_code"
+    t.bigint "favorite_currency_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "currency_followings", "currencies", column: "followed_currency_code", primary_key: "code"
-  add_foreign_key "currency_followings", "users", column: "follower_email", primary_key: "email"
-  add_foreign_key "currency_records", "currencies", column: "code", primary_key: "code"
-  add_foreign_key "users", "currencies", column: "favorite_currency_code", primary_key: "code"
+  add_foreign_key "currency_followings", "currencies"
+  add_foreign_key "currency_followings", "users"
+  add_foreign_key "currency_records", "currencies"
+  add_foreign_key "users", "currencies", column: "favorite_currency_id"
 end

--- a/rails_app/spec/models/currency_record_spec.rb
+++ b/rails_app/spec/models/currency_record_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CurrencyRecord, type: :model do
 
     currency_record = CurrencyRecord.new
 
-    currency_record.code = curr.code
+    currency_record.currency_id = curr.id
     currency_record.latest_exchange_rate = 0.1
     currency_record.record_date = DateTime.now
 
@@ -24,13 +24,13 @@ RSpec.describe CurrencyRecord, type: :model do
 
       currency_record = CurrencyRecord.new
 
-      currency_record.code = ":("
+      currency_record.currency_id = -1
       currency_record.latest_exchange_rate = 0.1
       currency_record.record_date = DateTime.now
 
       expect(currency_record).to_not be_valid
 
-      currency_record.code = curr.code
+      currency_record.currency_id = curr.id
 
       expect(currency_record).to be_valid
     end
@@ -41,7 +41,7 @@ RSpec.describe CurrencyRecord, type: :model do
 
       currency_record = CurrencyRecord.new
 
-      currency_record.code = curr.code
+      currency_record.currency_id = curr.id
       currency_record.record_date = DateTime.now
       currency_record.latest_exchange_rate = 0
 


### PR DESCRIPTION
### **Schema**
- currencies: primary key changed from a string (`code`) to a sequential integer (`id`)
- other tables: updated foreign keys to reflect the change above.

### **Models**
Schema changes allows ActiveRecord associations to be less verbose, by leveraging Rails' defaults (`<Modelname>_id`).

### **Controllers/Views**
Some controllers, views and helpers that were making queries to the ActiveRecords that changed had to be updated.