### PR TITLE
3 :: View to edit only favourite currency

### DIFF
--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -47,7 +47,9 @@ class CurrenciesController < ApplicationController
   end
 
   def change_favorite
-    if current_user.update favorite_currency_id: params[:user][:favorite_currency_id]
+    new_favorite = Currency.find_by id: params[:user][:favorite_currency_id]
+
+    if current_user.update favorite_currency: new_favorite
       redirect_to root_path
     end
   end

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -5,7 +5,7 @@
 #
 class CurrenciesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:follow, :unfollow, :followed]
+  before_action :authenticate_user!, only: [:follow, :unfollow, :followed, :change_favorite, :edit_favorite]
 
   # GET /currencies or /currencies.json
   def index
@@ -38,6 +38,16 @@ class CurrenciesController < ApplicationController
       user = current_user
 
       @followed_codes = user.followed_currencies.map { |curr| curr.code }
+    end
+  end
+
+  def edit_favorite
+    @user = current_user
+  end
+
+  def change_favorite
+    if current_user.update favorite_currency_id: params[:user][:favorite_currency_id]
+      redirect_to root_path
     end
   end
 

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -5,7 +5,7 @@
 #
 class CurrenciesController < ApplicationController
 
-  before_action :authenticate_user!, only: [:follow, :unfollow, :followed, :change_favorite, :edit_favorite]
+  before_action :authenticate_user!, except: [:index, :show, :all]
 
   # GET /currencies or /currencies.json
   def index
@@ -15,6 +15,18 @@ class CurrenciesController < ApplicationController
       redirect_to all_currencies_path
     end
   end
+  
+  # GET /currencies/all or /currencies/all.json
+  def all
+    @currencies = Currency.all
+
+    if user_signed_in?
+      user = current_user
+
+      @followed_codes = user.followed_currencies.map { |curr| curr.code }
+    end
+  end
+
 
   # GET /currencies/EUR or /currencies/EUR.json
   def show
@@ -28,17 +40,6 @@ class CurrenciesController < ApplicationController
     @currencies = user.followed_currencies
 
     @followed_codes = @currencies.map { |curr| curr.code }
-  end
-
-  # GET /currencies/all or /currencies/all.json
-  def all
-    @currencies = Currency.all
-
-    if user_signed_in?
-      user = current_user
-
-      @followed_codes = user.followed_currencies.map { |curr| curr.code }
-    end
   end
 
   def edit_favorite
@@ -67,6 +68,7 @@ class CurrenciesController < ApplicationController
     handle_result CurrencyFollowerManager.call user: user, currency: currency, follow: false
   end
 
+  private
   #
   # Handles the result of an interactor
   #

--- a/rails_app/app/controllers/currencies_controller.rb
+++ b/rails_app/app/controllers/currencies_controller.rb
@@ -23,7 +23,7 @@ class CurrenciesController < ApplicationController
     if user_signed_in?
       user = current_user
 
-      @followed_codes = user.followed_currencies.map { |curr| curr.code }
+      @followed_codes = user.followed_currencies.pluck(:code)
     end
   end
 
@@ -39,7 +39,7 @@ class CurrenciesController < ApplicationController
 
     @currencies = user.followed_currencies
 
-    @followed_codes = @currencies.map { |curr| curr.code }
+    @followed_codes = @currencies.pluck(:code)
   end
 
   def edit_favorite

--- a/rails_app/app/views/currencies/edit_favorite.html.erb
+++ b/rails_app/app/views/currencies/edit_favorite.html.erb
@@ -1,0 +1,18 @@
+<div class="page-form">
+
+  <h1>Edit Favorite Currency</h1>
+
+  <%= form_for(@user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: @user %>
+
+    <div class="field">
+      <%= f.label :favorite_currency_id %>
+      <%= f.select :favorite_currency_id, Currency.all.collect { |curr| ["#{curr.symbol}: #{curr.name}", curr.id] }, include_blank: true %>
+    </div>
+
+    <%= f.submit "Update" %>
+
+  <% end %>
+
+</div>
+

--- a/rails_app/app/views/currencies/edit_favorite.html.erb
+++ b/rails_app/app/views/currencies/edit_favorite.html.erb
@@ -2,8 +2,8 @@
 
   <h1>Edit Favorite Currency</h1>
 
-  <%= form_for(@user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: @user %>
+  <%= form_for(current_user, url: change_favorite_currency_path, html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: current_user %>
 
     <div class="field">
       <%= f.label :favorite_currency_id %>

--- a/rails_app/app/views/layouts/application.html.erb
+++ b/rails_app/app/views/layouts/application.html.erb
@@ -42,7 +42,9 @@
 
       <div class="container py-4 px-8">
         <% if defined?(current_user.favorite_currency) && current_user.favorite_currency != nil %>
-          Your favorite currency is <%= current_user.favorite_currency.code %> (<%= current_user.favorite_currency.symbol %>)
+          Your favorite currency is <%= current_user.favorite_currency.code %> (<%= current_user.favorite_currency.symbol %>). Change it <%= link_to "here", change_favorite_currency_path %>
+        <% else %>
+          You don't have a favorite currency. Set one <%= link_to "here", change_favorite_currency_path %>
         <% end %>
         <div class="max-w-full flex flex-col gap-5 place-items-center">
           <%= yield %>

--- a/rails_app/config/routes.rb
+++ b/rails_app/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   get "currencies/followed", to: "currencies#followed", as: "followed_currencies"
   get "currencies/all", to: "currencies#all", as: "all_currencies"
+  get "currencies/change_favorite", to: "currencies#edit_favorite", as: "edit_favorite_currency"
+  put "currencies/change_favorite", to: "currencies#change_favorite", as: "change_favorite_currency"
 
   resources :currencies, only: [:show, :index] do
 


### PR DESCRIPTION
Previously the user had to edit his registration info to change his favourite currency, which flooded him with unnecessary information which contributed to a worse UX.

Now, in a separate view, the user can edit **only** his favourite currency without the need for his current password.